### PR TITLE
added auth header, refactored, added tests

### DIFF
--- a/lib/lita/handlers/jenkins.rb
+++ b/lib/lita/handlers/jenkins.rb
@@ -14,49 +14,37 @@ module Lita
       end
 
       route /j(?:enkins)? list( (.+))?/i, :jenkins_list, command: true, help: {
-        'jekins list <filter>' => 'lists Jenkins jobs'
+        'jenkins list <filter>' => 'lists Jenkins jobs'
       }
 
-      route /j(?:enkins)? b (\d+)/i, :jenkins_build_by_id, command: true, help: {
-        'jekins b <job_id>' => 'builds the job specified by job_id. List jobs to get ID.'
+      route /j(?:enkins)? b(?:uild)? (\d+)/i, :jenkins_build, command: true, help: {
+        'jenkins b(uild) <job_id>' => 'builds the job specified by job_id. List jobs to get ID.'
       }
 
-      def jenkins_build_by_id(response)
-        job = jobs[response.matches.last.last.to_i - 1]
+      def jenkins_build(response)
+        if job = jobs[response.matches.last.last.to_i - 1]
+          url    = Lita.config.handlers.jenkins.url
+          path   = "#{url}/job/#{job['name']}/build"
 
-        if job
-          jenkins_build(response, job['name'])
+          http_resp = http.post(path) do |req|
+            req.headers = headers
+          end
+
+          if http_resp.status == 201
+            response.reply "(#{http_resp.status}) Build started for #{job['name']} #{url}/job/#{job['name']}"
+          else
+            response.reply http_resp.body
+          end
         else
           response.reply "I couldn't find that job. Try `jenkins list` to get a list."
         end
       end
 
-      def jenkins_build(response, job_name=nil)
-        url    = Lita.config.handlers.jenkins.url
-        auth64 = Base64.encode64(Lita.config.handlers.jenkins.auth)
-        path   = "#{url}/job/#{job_name}/build"
-
-        http_resp = http.post(path) do |req|
-          req.headers['Authorization'] = "Basic #{auth64}"
-        end
-
-        if http_resp.status == 201
-          response.reply "(#{http_resp.status}) Build started for #{job_name} #{url}/job/#{job_name}"
-        else
-          response.reply http_resp.body
-        end
-      end
-
       def jenkins_list(response)
-        url             = Lita.config.handlers.jenkins.url
-        path            = "#{url}/api/json"
-        filter          = response.matches.first.last
+        filter = response.matches.first.last
+        reply  = ''
 
-        api_response    = http.get(path)
-        parsed_response = JSON.parse(api_response.body)
-        reply = ''
-
-        parsed_response['jobs'].each_with_index do |job, i|
+        jobs.each_with_index do |job, i|
           job_name      = job['name']
           state         = color_to_state(job['color'])
           text_to_check = state + job_name
@@ -64,12 +52,25 @@ module Lita
           reply << format_job(i, state, job_name) if filter_match(filter, text_to_check)
         end
 
-        cache_job_list(parsed_response['jobs'])
-
         response.reply reply
       end
 
+      def headers
+        headers = {}
+        if auth = Lita.config.handlers.jenkins.auth
+          headers["Authorization"] = "Basic #{Base64.encode64(auth).chomp}"
+        end
+        headers
+      end
+
       def jobs
+        if self.class.jobs.empty?
+          path = "#{Lita.config.handlers.jenkins.url}/api/json"
+          api_response = http.get(path) do |req|
+            req.headers = headers
+          end
+          self.class.jobs = JSON.parse(api_response.body)["jobs"]
+        end
         self.class.jobs
       end
 
@@ -92,10 +93,6 @@ module Lita
 
       def filter_match(filter, text)
         text.match(/#{filter}/i)
-      end
-
-      def cache_job_list(jobs)
-        self.class.jobs = jobs if self.class.jobs.empty?
       end
     end
 


### PR DESCRIPTION
- I added the auth header to the "jenkins list" call as opposed to JUST the build calls. Our jenkins installation is all behind an auth screen (not just the build calls). I did some testing that seemed to indicate that sending the authorization header for URLs that didn't need it had no real effect.
- Refactored ...
  - I moved the authorization handling into a single method called headers. I guessed that if later headers were needed they'd be easy to inject here.
  - The auth header is now optional, however, I doubt very many people have their Jenkins installation setup that way. :smile: 
  - I changed the caching of the job list to lazy load instead of explicitly calling the cache method. This was also important because there was a bug where if the user hadn't called "jenkins list" first and just tried to do a build, the build would fail.
  - Collapsed the jenkins_build_by_id into the jenkins_build method
- Fixed typo in the help output
- Changed the regex to cover both "jenkins b ID" and "jenkins build ID"
- Added tests to cover the "jenkins build" action
