### PR TITLE
Handle recent deprecation warnings in tests

### DIFF
--- a/spec/lita/handlers/jenkins_spec.rb
+++ b/spec/lita/handlers/jenkins_spec.rb
@@ -1,8 +1,8 @@
 require "spec_helper"
 
 describe Lita::Handlers::Jenkins, lita_handler: true do
-  it { routes_command('jenkins list').to(:jenkins_list) }
-  it { routes_command('jenkins list filter').to(:jenkins_list) }
+  it { is_expected.to route_command('jenkins list').to(:jenkins_list) }
+  it { is_expected.to route_command('jenkins list filter').to(:jenkins_list) }
 
   describe '#jenkins list' do
     let(:response) { double("Faraday::Response") }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,3 +8,5 @@ SimpleCov.start { add_filter "/spec/" }
 
 require "lita-jenkins"
 require "lita/rspec"
+
+Lita.version_3_compatibility_mode = false


### PR DESCRIPTION
> WARNING: Lita 3 compatibility mode is currently enabled. It is recommended that you disable it by adding the following code to spec/spec_helper.rb:

    require "lita/rspec"
    Lita.version_3_compatibility_mode = false

>This will ensure that your test suite works with all the changes introduced in Lita 4. The compatibility mode will be removed in Lita 5.

and:

> `routes_command` is deprecated and will be removed in Lita 5.0. Use `is_expected.to route_command` instead.