### PR TITLE
Enable use of a job name input to commands

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ sudo: false
 language: ruby
 cached: true
 rvm:
-  - 2.0.0
   - 2.1
   - 2.2
 script: bundle exec rake

--- a/lib/lita/handlers/jenkins.rb
+++ b/lib/lita/handlers/jenkins.rb
@@ -1,16 +1,20 @@
 require 'json'
 require 'base64'
 
-# Determine if a given String is contains only a number.
-class String
-  def number?
-    /\A[-+]?\d+\z/ === self
+module StringRefinements
+  # Determine if a given String is contains only a number.
+  refine String do
+    def number?
+      /\A[-+]?\d+\z/ === self
+    end
   end
 end
 
 module Lita
   module Handlers
     class Jenkins < Handler
+      using StringRefinements
+
       class << self
         attr_accessor :jobs
       end

--- a/lib/lita/handlers/jenkins.rb
+++ b/lib/lita/handlers/jenkins.rb
@@ -3,7 +3,7 @@ require 'base64'
 
 # Determine if a given String is contains only a number.
 class String
-  def is_i?
+  def number?
     /\A[-+]?\d+\z/ === self
   end
 end
@@ -31,7 +31,7 @@ module Lita
       def jenkins_build(response)
         requested_job = response.matches.last.last
 
-        if requested_job.is_i?
+        if requested_job.number?
           inputjob = jobs[requested_job.to_i - 1]
         else
           inputjob = jobs.select { |j| j['name'] == requested_job }.last

--- a/lita-jenkins.gemspec
+++ b/lita-jenkins.gemspec
@@ -14,6 +14,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
+  spec.required_ruby_version = ">= 2.1"
+
   spec.add_runtime_dependency "lita", ">= 3.0"
 
   spec.add_development_dependency "bundler", "~> 1.3"

--- a/spec/lita/handlers/jenkins_spec.rb
+++ b/spec/lita/handlers/jenkins_spec.rb
@@ -49,10 +49,24 @@ describe Lita::Handlers::Jenkins, lita_handler: true do
       expect(replies.last).to eq("(201) Build started for deploy /job/deploy")
     end
 
+    it 'build job name' do
+      allow(response).to receive(:status).and_return(201)
+      allow(response).to receive(:body).and_return(api_response)
+      send_command('jenkins b deploy')
+      expect(replies.last).to eq("(201) Build started for deploy /job/deploy")
+    end
+
     it 'build job bad id' do
       allow(response).to receive(:status).and_return(201)
       allow(response).to receive(:body).and_return(api_response)
       send_command('jenkins b 99')
+      expect(replies.last).to eq("I couldn't find that job. Try `jenkins list` to get a list.")
+    end
+
+    it 'build job bad name' do
+      allow(response).to receive(:status).and_return(201)
+      allow(response).to receive(:body).and_return(api_response)
+      send_command('jenkins b sloppyjob')
       expect(replies.last).to eq("I couldn't find that job. Try `jenkins list` to get a list.")
     end
 


### PR DESCRIPTION
Extends the String class to add an inspector on a returned match to
determine if the input is a word or only a series of digits (job id).

Fixes #4