### PR TITLE
Update capture expression to accommodate hyphens

### DIFF
--- a/lib/lita/handlers/jenkins.rb
+++ b/lib/lita/handlers/jenkins.rb
@@ -28,7 +28,7 @@ module Lita
         'jenkins list <filter>' => 'lists Jenkins jobs'
       }
 
-      route /j(?:enkins)? b(?:uild)? (\w+)/i, :jenkins_build, command: true, help: {
+      route /j(?:enkins)? b(?:uild)? ([\w\.\-_ ]+)/i, :jenkins_build, command: true, help: {
         'jenkins b(uild) <job_id or job_name>' => 'builds the job specified by ID or name. List jobs to get ID.'
       }
 

--- a/spec/lita/handlers/jenkins_spec.rb
+++ b/spec/lita/handlers/jenkins_spec.rb
@@ -56,6 +56,20 @@ describe Lita::Handlers::Jenkins, lita_handler: true do
       expect(replies.last).to eq("(201) Build started for deploy /job/deploy")
     end
 
+    it 'build job underscored name' do
+      allow(response).to receive(:status).and_return(201)
+      allow(response).to receive(:body).and_return(api_response)
+      send_command('jenkins b chef_converge')
+      expect(replies.last).to eq("(201) Build started for chef_converge /job/chef_converge")
+    end
+
+    it 'build job hyphenated name' do
+      allow(response).to receive(:status).and_return(201)
+      allow(response).to receive(:body).and_return(api_response)
+      send_command('jenkins b build-all')
+      expect(replies.last).to eq("(201) Build started for build-all /job/build-all")
+    end
+
     it 'build job bad id' do
       allow(response).to receive(:status).and_return(201)
       allow(response).to receive(:body).and_return(api_response)


### PR DESCRIPTION
Introduced in #6, the regular expression capture group would not
accommodate names like `build-all` - as the last match of that group was
`all`, and there was no build by that name.

Accompanied by tests.