### PR TITLE
Convert variable assignment to happen inside an if

### DIFF
--- a/lib/lita/handlers/jenkins.rb
+++ b/lib/lita/handlers/jenkins.rb
@@ -35,11 +35,11 @@ module Lita
       def jenkins_build(response)
         requested_job = response.matches.last.last
 
-        if requested_job.number?
-          job = jobs[requested_job.to_i - 1]
-        else
-          job = jobs.select { |j| j['name'] == requested_job }.last
-        end
+        job = if requested_job.number?
+                jobs[requested_job.to_i - 1]
+              else
+                jobs.select { |j| j['name'] == requested_job }.last
+              end
 
         if job
           url    = Lita.config.handlers.jenkins.url


### PR DESCRIPTION
Really a no-op, but assigns the `job` variable once, based on the logic
flow inside the following `if` block.

See https://github.com/bbatsov/ruby-style-guide#use-if-case-returns for
other examples.