### PR TITLE
Use correct syntax to cache bundled gems

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 sudo: false
 language: ruby
-cached: true
+cache: bundler
 rvm:
   - 2.1
   - 2.2


### PR DESCRIPTION
Previously introduced in #7, speedups were immediately seen with
containers, but there's still significant time spent on retrieving gems.