### PR TITLE
Remove jobs memoization

### DIFF
--- a/lib/lita/handlers/jenkins.rb
+++ b/lib/lita/handlers/jenkins.rb
@@ -15,14 +15,6 @@ module Lita
     class Jenkins < Handler
       using StringRefinements
 
-      class << self
-        attr_accessor :jobs
-
-        def jobs
-          @jobs ||= {}
-        end
-      end
-
       config :auth
       config :url
 
@@ -85,14 +77,11 @@ module Lita
       end
 
       def jobs
-        if self.class.jobs.empty?
-          path = "#{config.url}/api/json"
-          api_response = http.get(path) do |req|
-            req.headers = headers
-          end
-          self.class.jobs = JSON.parse(api_response.body)["jobs"]
+        path = "#{config.url}/api/json"
+        api_response = http.get(path) do |req|
+          req.headers = headers
         end
-        self.class.jobs
+        JSON.parse(api_response.body)["jobs"]
       end
 
       private


### PR DESCRIPTION
Instead of storing a static jobs list on the running instance, perform
an API call for every build command.

Simplifies the code, fixes a condition where jobs added after the first
`list` command will never be seen until lita instance restart.

Fixes #17