### PR TITLE
Simplify headers method

### DIFF
--- a/lib/lita/handlers/jenkins.rb
+++ b/lib/lita/handlers/jenkins.rb
@@ -77,11 +77,9 @@ module Lita
       end
 
       def headers
-        headers = {}
-        if auth = config.auth
-          headers["Authorization"] = "Basic #{Base64.encode64(auth).chomp}"
+        {}.tap do |headers|
+          headers["Authorization"] = "Basic #{Base64.encode64(config.auth).chomp}" if config.auth
         end
-        headers
       end
 
       def jobs

--- a/spec/lita/handlers/jenkins_spec.rb
+++ b/spec/lita/handlers/jenkins_spec.rb
@@ -31,6 +31,19 @@ describe Lita::Handlers::Jenkins, lita_handler: true do
     allow_any_instance_of(Faraday::Connection).to receive(:post).and_return(response)
   end
 
+  describe '#headers' do
+    it 'returns empty auth headers correctly by default' do
+      return_value = described_class.new(robot).headers
+      expect(return_value.inspect).to eq("{}")
+    end
+
+    it 'encodes auth headers correctly' do
+      registry.config.handlers.jenkins.auth = "foo:bar"
+      return_value = described_class.new(robot).headers
+      expect(return_value.inspect).to eq("{\"Authorization\"=>\"Basic Zm9vOmJhcg==\"}")
+    end
+  end
+
   describe '#jenkins list' do
     it 'lists all jenkins jobs' do
       allow(response).to receive(:status).and_return(200)
@@ -95,12 +108,6 @@ describe Lita::Handlers::Jenkins, lita_handler: true do
       allow(response).to receive(:body).and_return(api_response)
       send_command('jenkins b 2')
       expect(replies.last).to eq(api_response)
-    end
-
-    it 'encodes auth headers correctly' do
-      registry.config.handlers.jenkins.auth = "foo:bar"
-      return_value = described_class.new(robot).headers
-      expect(return_value.inspect).to eq("{\"Authorization\"=>\"Basic Zm9vOmJhcg==\"}")
     end
   end
 end


### PR DESCRIPTION
- Removes assignment in condition for `auth = config.auth` in favor of
  inline condition for the specific header.
- Removes extra object assignment for `auth`, preferring to use
  config.auth directly.
- Uses `Object#tap` on an empty Hash to prevent the need for explicit
  return of the object from the block.
- Moves specs to their own section out of `build`