### PR TITLE
Extract the job selection to its own method

### DIFF
--- a/lib/lita/handlers/jenkins.rb
+++ b/lib/lita/handlers/jenkins.rb
@@ -27,13 +27,7 @@ module Lita
       }
 
       def jenkins_build(response)
-        requested_job = response.matches.last.last
-
-        job = if requested_job.number?
-                jobs[requested_job.to_i - 1]
-              else
-                jobs.select { |j| j['name'] == requested_job }.last
-              end
+        job = find_job(response.matches.last.last)
 
         if job
           url    = config.url
@@ -85,6 +79,14 @@ module Lita
 
       def api_url
         "#{config.url}/api/json"
+      end
+
+      def find_job(requested_job)
+        if requested_job.number?
+          jobs[requested_job.to_i - 1]
+        else
+          jobs.select { |j| j['name'] == requested_job }.last
+        end
       end
 
       def format_job(i, state, job_name)


### PR DESCRIPTION
Cleans up code, the `find_job` method takes the requested job as a
parameter, and uses the `jobs` method to get the list of jobs.

I debated whether during this extraction it would make sense to remove the `StringRefinements` module, as `number?` seems to be used now in only the `find_job` method.

This would result in the condition looking more like:

```ruby
        if requested_job.match(/\A[-+]?\d+\z/)
          jobs[requested_job.to_i - 1]
        else
...
```

I am leaning towards removing the refine, but wanted to get your input before.