### PR TITLE
Move job not found response to earlier, outdent

### DIFF
--- a/lib/lita/handlers/jenkins.rb
+++ b/lib/lita/handlers/jenkins.rb
@@ -29,21 +29,22 @@ module Lita
       def jenkins_build(response)
         job = find_job(response.matches.last.last)
 
-        if job
-          url    = config.url
-          path   = "#{url}/job/#{job['name']}/build"
-
-          http_resp = http.post(path) do |req|
-            req.headers = headers
-          end
-
-          if http_resp.status == 201
-            response.reply "(#{http_resp.status}) Build started for #{job['name']} #{url}/job/#{job['name']}"
-          else
-            response.reply http_resp.body
-          end
-        else
+        unless job
           response.reply "I couldn't find that job. Try `jenkins list` to get a list."
+          return
+        end
+
+        url  = config.url
+        path = "#{url}/job/#{job['name']}/build"
+
+        http_resp = http.post(path) do |req|
+          req.headers = headers
+        end
+
+        if http_resp.status == 201
+          response.reply "(#{http_resp.status}) Build started for #{job['name']} #{url}/job/#{job['name']}"
+        else
+          response.reply http_resp.body
         end
       end
 


### PR DESCRIPTION
If there is no `job` found, bail earlier in the method. This favors the
"fail early" approach, removing one conditional branch from the method,
as we assume that if `job` is not nil, we must have a job object to work
with.