### PR TITLE
Extract URL composition to distinct methods

### DIFF
--- a/lib/lita/handlers/jenkins.rb
+++ b/lib/lita/handlers/jenkins.rb
@@ -24,15 +24,15 @@ module Lita
           return
         end
 
-        url  = config.url
-        path = "#{url}/job/#{job['name']}/build"
+        named_job_url = job_url(job['name'])
+        path = job_build_url(named_job_url)
 
         http_resp = http.post(path) do |req|
           req.headers = headers
         end
 
         if http_resp.status == 201
-          response.reply "(#{http_resp.status}) Build started for #{job['name']} #{url}/job/#{job['name']}"
+          response.reply "(#{http_resp.status}) Build started for #{job['name']} #{named_job_url}"
         else
           response.reply http_resp.body
         end
@@ -70,6 +70,14 @@ module Lita
 
       def api_url
         "#{config.url}/api/json"
+      end
+
+      def job_url(job_name)
+        "#{config.url}/job/#{job_name}"
+      end
+
+      def job_build_url(named_job_url)
+        "#{named_job_url}/build"
       end
 
       def find_job(requested_job)


### PR DESCRIPTION
Attempt at extracting the URL composition from the main build method to individual methods.

I'm not certain this is the best way to do it, but as I've been working on parameterized builds, I thought I'd take the working code (which continues to grow with complexity), and see where simplification could occur.

This would be a stepping stone towards that, where the next step is to have the `job_build_url` take in more parameters and make a decision on what build URL to return based on inputs.
I had them working inline, but it started to look a little confusing, so I stepped back and tried this first.