### PR TITLE
Expose Faraday config options in plugin config

### DIFF
--- a/lib/lita/handlers/jenkins.rb
+++ b/lib/lita/handlers/jenkins.rb
@@ -7,6 +7,7 @@ module Lita
 
       config :auth
       config :url
+      config :http_options, required: false, type: Hash, default: {}
 
       route /j(?:enkins)? list( (.+))?/i, :jenkins_list, command: true, help: {
         'jenkins list <filter>' => 'lists Jenkins jobs'
@@ -31,7 +32,7 @@ module Lita
         named_job_url = job_url(job['name'])
         path = job_build_url(named_job_url, params)
 
-        http_resp = http.post(path) do |req|
+        http_resp = http(config.http_options).post(path) do |req|
           req.headers = headers
           req.params  = params if params.is_a? Hash
         end
@@ -70,7 +71,7 @@ module Lita
       end
 
       def jobs
-        api_response = http.get(api_url) do |req|
+        api_response = http(config.http_options).get(api_url) do |req|
           req.headers = headers
         end
         JSON.parse(api_response.body)["jobs"]

--- a/spec/lita/handlers/jenkins_spec.rb
+++ b/spec/lita/handlers/jenkins_spec.rb
@@ -45,6 +45,43 @@ describe Lita::Handlers::Jenkins, lita_handler: true do
     end
   end
 
+  describe '#http_options' do
+    it 'handles no options specified by default' do
+      http = described_class.new(robot).http
+      expect(http.options.empty?).to be true
+    end
+
+    it 'sets default http options on jobs request' do
+      handler = described_class.new(robot)
+      expect(handler).to receive(:http).with({}).and_call_original
+      allow(response).to receive(:body).and_return(api_response)
+      handler.jobs
+    end
+
+    it 'sets default http options for build' do
+      expect_any_instance_of(Lita::Handlers::Jenkins).to receive(:http).twice.with({}).and_call_original
+      allow(response).to receive(:body).and_return(api_response)
+      allow(response).to receive(:status).and_return(201)
+      send_command('jenkins b deploy')
+    end
+
+    it 'sets configured http options on jobs request' do
+      registry.config.handlers.jenkins.http_options = { url: 'http://test.com' }
+      handler = described_class.new(robot)
+      expect(handler).to receive(:http).with({ url: 'http://test.com' }).and_call_original
+      allow(response).to receive(:body).and_return(api_response)
+      handler.jobs
+    end
+
+    it 'sets configured http options for build' do
+      registry.config.handlers.jenkins.http_options = { url: 'http://test.com' }
+      expect_any_instance_of(Lita::Handlers::Jenkins).to receive(:http).twice.with({ url: 'http://test.com' }).and_call_original
+      allow(response).to receive(:body).and_return(api_response)
+      allow(response).to receive(:status).and_return(201)
+      send_command('jenkins b deploy')
+    end
+  end
+
   describe '#jenkins list' do
     it 'lists all jenkins jobs' do
       allow(response).to receive(:status).and_return(200)


### PR DESCRIPTION
In order to specify options for the underlying Faraday http connection, this PR adds a configuration option  for supplying the desired hash of configuration options.