### PR TITLE
Use Base64.strict_encode64 for encoding Authorization header.

### DIFF
--- a/lib/lita/handlers/jenkins.rb
+++ b/lib/lita/handlers/jenkins.rb
@@ -66,7 +66,7 @@ module Lita
 
       def headers
         {}.tap do |headers|
-          headers["Authorization"] = "Basic #{Base64.encode64(config.auth).chomp}" if config.auth
+          headers["Authorization"] = "Basic #{Base64.strict_encode64(config.auth).chomp}" if config.auth
         end
       end
 

--- a/spec/lita/handlers/jenkins_spec.rb
+++ b/spec/lita/handlers/jenkins_spec.rb
@@ -43,6 +43,12 @@ describe Lita::Handlers::Jenkins, lita_handler: true do
       return_value = described_class.new(robot).headers
       expect(return_value.inspect).to eq("{\"Authorization\"=>\"Basic Zm9vOmJhcg==\"}")
     end
+
+    it 'encodes auth headers without line breaks' do
+      registry.config.handlers.jenkins.auth = "foo:thisisalongtokenthatmighthavelinebreakswithoutstrict"
+      return_value = described_class.new(robot).headers
+      expect(return_value.inspect).to eq("{\"Authorization\"=>\"Basic Zm9vOnRoaXNpc2Fsb25ndG9rZW50aGF0bWlnaHRoYXZlbGluZWJyZWFrc3dpdGhvdXRzdHJpY3Q=\"}")
+    end
   end
 
   describe '#http_options' do


### PR DESCRIPTION
When you don't use strict encoding you can end up with line breaks in the
encoded header for longer authentication tokens (e.g. those from GitHub
personal tokens).